### PR TITLE
Allow to specify on which bus MAX3010x sensor is located

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDE an code editor configs
+.idea
+.vscode

--- a/max30102/max30102.go
+++ b/max30102/max30102.go
@@ -26,8 +26,9 @@ type Device struct {
 // samples/s.
 //
 // Argument "busName" can be used to specify the exact bus to use ("/dev/i2c-2", "I2C2", "2").
+// Argument "addr" can be used to specify alternative address if default (0x57) is unavailable and changed.
 // If "busName" argument is specified as an empty string "" the first available bus will be used.
-func New(busName string) (*Device, error) {
+func New(busName string, addr uint16) (*Device, error) {
 	if _, err := host.Init(); err != nil {
 		return nil, fmt.Errorf("max30102: could not initialize host: %w", err)
 	}
@@ -36,8 +37,13 @@ func New(busName string) (*Device, error) {
 	if err != nil {
 		return nil, fmt.Errorf("max30102: could not open i2c bus: %w", err)
 	}
+
+	if addr == 0 {
+		addr = Addr
+	}
+
 	dev := &i2c.Dev{
-		Addr: Addr,
+		Addr: addr,
 		Bus:  bus,
 	}
 

--- a/max30102/max30102.go
+++ b/max30102/max30102.go
@@ -24,12 +24,15 @@ type Device struct {
 // New returns a new MAX30102 device. By default, this sets the LED pulse
 // amplitude to 2.4mA, with a pulse width of 411us and a sample rate of 100
 // samples/s.
-func New() (*Device, error) {
+//
+// Argument "busName" can be used to specify the exact bus to use ("/dev/i2c-2", "I2C2", "2").
+// If "busName" argument is specified as an empty string "" the first available bus will be used.
+func New(busName string) (*Device, error) {
 	if _, err := host.Init(); err != nil {
 		return nil, fmt.Errorf("max30102: could not initialize host: %w", err)
 	}
 
-	bus, err := i2creg.Open("")
+	bus, err := i2creg.Open(busName)
 	if err != nil {
 		return nil, fmt.Errorf("max30102: could not open i2c bus: %w", err)
 	}

--- a/max3010x.go
+++ b/max3010x.go
@@ -57,7 +57,15 @@ const threshold = 0.10
 
 // New returns a new MAX3010x device.
 func New() (*Device, error) {
-	sensor, err := max30102.New()
+	return NewOnBus("")
+}
+
+// NewOnBus returns a new MAX3010x device located on a specific bus.
+//
+// Use NewOnBus if an application knows the exact bus to use ("/dev/i2c-2", "I2C2", "2").
+// If "bus" argument is specified as an empty string "" the first available bus will be used.
+func NewOnBus(bus string) (*Device, error) {
+	sensor, err := max30102.New(bus)
 	if err != nil {
 		return nil, err
 	}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,37 @@
+package max3010x
+
+// An Option configures a device.
+type Option interface {
+	Apply(*Device)
+}
+
+// OptionFunc is a function that configures a device.
+type OptionFunc func(device *Device)
+
+// Apply calls OptionFunc on device instance
+func (f OptionFunc) Apply(device *Device) {
+	f(device)
+}
+
+// WithSpecificBus can be used to specify I²C bus name
+// ("/dev/i2c-2", "I2C2", "2").
+func WithSpecificBus(name string) Option {
+	return OptionFunc(func(d *Device) {
+		d.bus = name
+	})
+}
+
+// WithAddress can be used to specify alternative I²C name.
+// if default (0x57) is unavailable and changed
+func WithAddress(addr uint16) Option {
+	return OptionFunc(func(d *Device) {
+		d.addr = addr
+	})
+}
+
+// WithSensor can be used to mock alternative sensor implementation.
+func WithSensor(sensor sensor) Option {
+	return OptionFunc(func(d *Device) {
+		d.sensor = sensor
+	})
+}


### PR DESCRIPTION
Hi there, Eiji Onchi!
Thanks for the `max3010x` library, it just made my life so much easier! 

However, in my project I use multiply sensors on a single RPi Zero W (and yes, it works perfectly there too). 
So, I have 4 I2C buses, and since I could not guarantee that **MAX30102** will be connected via the first one I need a way to specify which exact bus to connect to.

So, I made some minor changes and add `NewOnBus` constructor to allow just that.
It will be cool to merge my fork to your original repo and made your library even more useful!

Please review my changes and do tell me if I can make them more fitting for you lib.